### PR TITLE
Use old session serializer for django social auth

### DIFF
--- a/manoseimas/settings/base.py
+++ b/manoseimas/settings/base.py
@@ -313,3 +313,7 @@ THUMBNAIL_QUALITY = 100
 
 # This is only for anonymous users and is overriden when a user logs in.
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+
+# Django-social-auth does not support JSON serializer.
+# See: https://docs.djangoproject.com/en/1.8/topics/http/sessions/#session-serialization
+SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'


### PR DESCRIPTION
Since Django 1.6, for security reasons Django session serializer was changed to
JSON. But django-social-auth does not work with JSON serializer, so I'm
changing serializer back to Pickle.

See also: https://docs.djangoproject.com/en/1.8/topics/http/sessions/#session-serialization