### PR TITLE
Sync CouchDB views for scrapy

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -35,6 +35,10 @@ Run migrations::
 
     bin/django migrate
 
+Sync CouchDB views for scrapy::
+
+    bin/initscrapy
+
 And run the project::
 
     make run

--- a/manoseimas/scrapy/couchdb/nodes/views/voting_by_date/map.js
+++ b/manoseimas/scrapy/couchdb/nodes/views/voting_by_date/map.js
@@ -1,0 +1,5 @@
+function(doc) {
+    if (doc.doc_type == "Voting") {
+        emit(doc.created.split("T")[0], null);
+    }
+}

--- a/manoseimas/scrapy/main.py
+++ b/manoseimas/scrapy/main.py
@@ -1,0 +1,24 @@
+from __future__ import unicode_literals, print_function
+
+import os
+import os.path
+
+from couchdbkit import Server
+from couchdbkit import push
+
+from manoseimas.scrapy.settings import COUCHDB_URL, BUILDOUT_DIR
+
+
+def main():
+    server = Server(COUCHDB_URL)
+    couchdb_dir = os.path.join(BUILDOUT_DIR, 'manoseimas', 'scrapy', 'couchdb')
+    for dbname in os.listdir(couchdb_dir):
+        print("sync %s..." % dbname)
+        db = server.get_or_create_db(dbname)
+        path = os.path.join(couchdb_dir, dbname)
+        push(path, db, force=True, docid='_design/scrapy')
+    print("done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/manoseimas/scrapy/settings.py
+++ b/manoseimas/scrapy/settings.py
@@ -35,9 +35,11 @@ HTTPCACHE_POLICY = 'manoseimas.scrapy.httpcache.NoCacheFlagPolicy'
 HTTPCACHE_STORAGE = 'scrapy.contrib.httpcache.LeveldbCacheStorage'
 HTTPCACHE_DIR = '/tmp/manoseimas_httpcache'
 
+COUCHDB_URL = 'http://127.0.0.1:5984'
+
 COUCHDB_DATABASES = (
-    ('legalact', 'http://127.0.0.1:5984', 'legalacts',),
-    ('question', 'http://127.0.0.1:5984', 'sittings',),
-    ('voting', 'http://127.0.0.1:5984', 'sittings',),
-    ('person', 'http://127.0.0.1:5984', 'mps',),
+    ('legalact', COUCHDB_URL, 'legalacts',),
+    ('question', COUCHDB_URL, 'sittings',),
+    ('voting', COUCHDB_URL, 'sittings',),
+    ('person', COUCHDB_URL, 'mps',),
 )

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     entry_points={
         'console_scripts': [
             'couch = manoseimas.scripts.couch:main',
+            'initscrapy = manoseimas.scrapy.main:main',
         ],
     }
 )


### PR DESCRIPTION
Currently all CouchDB views are synchorinzed using couchdbkit, but this works
only for Django apps and single app can synchronize single database.

manoseimas/scrapy is not Django app and it has to deal with both, sittings and
nodes databases, o couchdbkit can not be used here.

To sync views for scrapy I created simple script initscrapy, to do the job.