### PR TITLE
Switch to the faster container-based Travis CI infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .waf*
 .ropeproject
 .vagrant
+pip-selfcheck.json
 
 /bin
 /buildout.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: python
 python: "2.7"
+sudo: false
 services:
     - mysql
     - couchdb
 before_install:
     - mysql -uroot -e 'create database manoseimas;'
-    - sudo ln -s /usr/include/freetype2 /usr/include/freetype || true
     - printf "[client]\ndatabase = manoseimas\nuser = root\npassword =\ndefault-character-set = utf8\n" > ~/.my.cnf
 install:
-    - sudo make ubuntu
     - python scripts/genconfig.py config/env/development.cfg
     - make
 script:


### PR DESCRIPTION
Turns out there's no need to 'sudo make ubuntu-environment': everything
needed for the build is already present on Travis.  Proof:
https://travis-ci.org/mgedmin/manoseimas.lt/builds/80789140