### PR TITLE
Rip out modernizr

### DIFF
--- a/config/assets.cfg
+++ b/config/assets.cfg
@@ -1,5 +1,5 @@
 [buildout]
-parts += flot jquery modernizr bootstrap bootstrap-sass historyjs
+parts += flot jquery bootstrap bootstrap-sass historyjs
 
 
 [flot]
@@ -20,12 +20,6 @@ excludes =
 recipe = hexagonit.recipe.download
 url = http://code.jquery.com/jquery-1.7.min.js
 filename = jquery.min.js
-download-only = true
-
-
-[modernizr]
-recipe = hexagonit.recipe.download
-url = http://www.modernizr.com/downloads/modernizr.js
 download-only = true
 
 

--- a/manoseimas/settings/base.py
+++ b/manoseimas/settings/base.py
@@ -62,7 +62,6 @@ STATIC_ROOT = os.path.join(BUILDOUT_DIR, 'var', 'www', 'static')
 STATIC_URL = '/static/'
 STATICFILES_DIRS = (
     os.path.join(config.buildout_parts_dir, 'flot'),
-    os.path.join(config.buildout_parts_dir, 'modernizr'),
     os.path.join(config.buildout_parts_dir, 'jquery'),
     os.path.join(config.buildout_parts_dir, 'history.js'),
     os.path.join(config.buildout_parts_dir, 'bootstrap'),

--- a/manoseimas/templates/base.html
+++ b/manoseimas/templates/base.html
@@ -31,8 +31,6 @@
   <link rel="stylesheet" type="text/x-scss" href="{% static "main.scss" %}">
   <link rel="stylesheet" type="text/x-scss" href="{% static "fonts/open-sans/stylesheet.scss" %}">
   {% endcompress %}
-
-  <script src="{% static "modernizr.js" %}" type="text/javascript" charset="utf-8"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Modernizr cannot be downloaded, and this breaks builds.  I filed an
upstream bug here:
https://bitbucket.org/sirex/django-starter/issues/18/modernizr-cannot-be-downloaded

I don't know which Modernizr features to select in the builder at
https://modernizr.com/download?setclasses -- there are hundreds!  Let's
just rip it out in the mean time.