### PR TITLE
Fix for pagination button overlap with the footer

### DIFF
--- a/manoseimas/mps_v2/static/main.scss
+++ b/manoseimas/mps_v2/static/main.scss
@@ -70,6 +70,7 @@
 .law-projects {
   border-top: 1px solid #C8C8C8;
   padding-top: 2rem;
+  margin-bottom: 1.5rem;
 
   .eight.wide.column { padding-bottom: 0; }
   .ui.zero.margin.grid { margin: 0; }


### PR DESCRIPTION
Before:
![ekrano nuotrauka is 2015-10-26 12-28-04](https://cloud.githubusercontent.com/assets/159967/10726806/db1fd8dc-7bdd-11e5-9e39-228e00ecbeb7.png)

After:
![ekrano nuotrauka is 2015-10-26 12-32-56](https://cloud.githubusercontent.com/assets/159967/10726807/de58e69c-7bdd-11e5-9c20-2e6ea38fe50c.png)

I've checked: .law-projects is used in only one other place (MP profile), and this CSS change doesn't affect rendering there in any way:
![ekrano nuotrauka is 2015-10-26 12-30-18](https://cloud.githubusercontent.com/assets/159967/10726810/e597b0a0-7bdd-11e5-88f3-b7b1aebade43.png)

Fixes #102.