### PR TITLE
Scrape committee resolution titles

### DIFF
--- a/manoseimas/mps_v2/migrations/0027_add_committeeresolution.py
+++ b/manoseimas/mps_v2/migrations/0027_add_committeeresolution.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mps_v2', '0026_auto_20151027_1333'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CommitteeResolution',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('source', models.URLField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('modified_at', models.DateTimeField(auto_now=True)),
+                ('source_id', models.CharField(unique=True, max_length=16)),
+                ('title', models.TextField()),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+    ]

--- a/manoseimas/mps_v2/migrations/0028_backfill_committeeresolutions.py
+++ b/manoseimas/mps_v2/migrations/0028_backfill_committeeresolutions.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mps_v2', '0027_add_committeeresolution'),
+    ]
+
+    operations = [
+        migrations.RunSQL("""
+           INSERT IGNORE INTO mps_v2_committeeresolution (source_id, title, source)
+           SELECT DISTINCT source_id, '', source FROM mps_v2_suggestion
+        """),
+    ]

--- a/manoseimas/mps_v2/migrations/0028_backfill_committeeresolutions.py
+++ b/manoseimas/mps_v2/migrations/0028_backfill_committeeresolutions.py
@@ -11,9 +11,11 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # bug: keeps empty source, created_at, modified_at columns
-        migrations.RunSQL("""
-           INSERT IGNORE INTO mps_v2_committeeresolution (source_id, title, source)
-           SELECT DISTINCT source_id, '', source FROM mps_v2_suggestion
-        """),
+        migrations.RunSQL([
+            "INSERT IGNORE INTO mps_v2_committeeresolution (source_id, title) SELECT DISTINCT source_id, '' FROM mps_v2_suggestion",
+            "UPDATE mps_v2_committeeresolution SET created_at = utc_timestamp() WHERE created_at is NULL",
+            "UPDATE mps_v2_committeeresolution SET modified_at = utc_timestamp() WHERE modified_at is NULL",
+        ], [
+            "DELETE FROM mps_v2_committeeresolution",
+        ]),
     ]

--- a/manoseimas/mps_v2/migrations/0028_backfill_committeeresolutions.py
+++ b/manoseimas/mps_v2/migrations/0028_backfill_committeeresolutions.py
@@ -11,6 +11,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # bug: keeps empty source, created_at, modified_at columns
         migrations.RunSQL("""
            INSERT IGNORE INTO mps_v2_committeeresolution (source_id, title, source)
            SELECT DISTINCT source_id, '', source FROM mps_v2_suggestion

--- a/manoseimas/mps_v2/migrations/0029_link_suggestion_to_committeeresolution.py
+++ b/manoseimas/mps_v2/migrations/0029_link_suggestion_to_committeeresolution.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mps_v2', '0028_backfill_committeeresolutions'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='suggestion',
+            name='source_id',
+            field=models.ForeignKey(db_column=b'source_id', to_field=b'source_id', to='mps_v2.CommitteeResolution'),
+            preserve_default=False,
+        ),
+        migrations.RenameField(
+            model_name='suggestion',
+            old_name='source_id',
+            new_name='source_resolution',
+        ),
+        migrations.AlterUniqueTogether(
+            name='suggestion',
+            unique_together=set([('source_resolution', 'source_index')]),
+        ),
+    ]

--- a/manoseimas/mps_v2/migrations/0029_link_suggestion_to_committeeresolution.py
+++ b/manoseimas/mps_v2/migrations/0029_link_suggestion_to_committeeresolution.py
@@ -26,4 +26,11 @@ class Migration(migrations.Migration):
             name='suggestion',
             unique_together=set([('source_resolution', 'source_index')]),
         ),
+        # Workaround for https://code.djangoproject.com/ticket/25621
+        # D58bb2cf0b1407c8c24fa06b0cc34f38 is what you get from Django's
+        # BaseDatabaseSchemaEditor._create_index_name() when you pass it
+        # (model, ["source_id"], suffix="_fk_mps_v2_committeeresolution_source_id")
+        migrations.RunSQL([], [
+            "ALTER TABLE mps_v2_suggestion DROP FOREIGN KEY D58bb2cf0b1407c8c24fa06b0cc34f38",
+        ]),
     ]

--- a/manoseimas/mps_v2/models.py
+++ b/manoseimas/mps_v2/models.py
@@ -642,8 +642,15 @@ class Suggester(CrawledItem):
     title = models.TextField()
 
 
+class CommitteeResolution(CrawledItem):
+    source_id = models.CharField(max_length=16, unique=True)
+    title = models.TextField()
+
+
 class Suggestion(CrawledItem):
-    source_id = models.CharField(max_length=16, db_index=True)
+    source_resolution = models.ForeignKey(CommitteeResolution,
+                                          db_column='source_id',
+                                          to_field='source_id')
     source_index = models.IntegerField()
 
     submitter = models.ManyToManyField(Suggester, related_name='suggestions')
@@ -652,7 +659,7 @@ class Suggestion(CrawledItem):
     opinion = models.TextField(blank=True)
 
     class Meta:
-        unique_together = (('source_id', 'source_index'))
+        unique_together = (('source_resolution', 'source_index'))
 
     def __unicode__(self):
         return u'{} ({})'.format(self.submitter, self.opinion)

--- a/manoseimas/mps_v2/models.py
+++ b/manoseimas/mps_v2/models.py
@@ -684,11 +684,11 @@ class Suggestion(CrawledItem):
         rows = dict_fetch_all(cursor)
 
         counts = [{
-                'title': row['title'],
-                'suggestion_count': int(row['suggestion_count']),
-                'law_project_count': int(row['law_project_count']),
-                'state_actor': is_state_actor(row['title']),
-                } for row in rows]
+            'title': row['title'],
+            'suggestion_count': int(row['suggestion_count']),
+            'law_project_count': int(row['law_project_count']),
+            'state_actor': is_state_actor(row['title']),
+        } for row in rows]
 
         return counts
 

--- a/manoseimas/scrapy/items.py
+++ b/manoseimas/scrapy/items.py
@@ -267,4 +267,5 @@ class Suggestion(Item):
     source_url = Field()
     source_id = Field()
     source_index = Field()
+    source_title = Field()
     raw = Field()

--- a/manoseimas/scrapy/pipelines.py
+++ b/manoseimas/scrapy/pipelines.py
@@ -350,10 +350,18 @@ class ManoSeimasModelPersistPipeline(object):
     def process_suggestion(self, item, spider):
         suggester, created = SuggesterModel.objects.get_or_create(
             title=item['submitter'],
+            defaults={'source': item['source_url']},
         )
+        if not suggester.source:
+            suggester.source = item['source_url']
+            suggester.save()
         resolution, created = CommitteeResolution.objects.get_or_create(
             source_id=item['source_id'],
+            defaults={'source': item['source_url']},
         )
+        if not resolution.source:
+            resolution.source = item['source_url']
+            resolution.save()
         suggestion, created = SuggestionModel.objects.get_or_create(
             source_resolution=resolution,
             source_index=item['source_index'],
@@ -362,7 +370,7 @@ class ManoSeimasModelPersistPipeline(object):
         suggestion.date = item['date'] or None
         suggestion.document = item['document']
         suggestion.opinion = item['opinion']
-        suggestion.source_url = item['source_url']
+        suggestion.source = item['source_url']
         suggestion.save()
         return item
 

--- a/manoseimas/scrapy/pipelines.py
+++ b/manoseimas/scrapy/pipelines.py
@@ -361,7 +361,8 @@ class ManoSeimasModelPersistPipeline(object):
         )
         if not resolution.source:
             resolution.source = item['source_url']
-            resolution.save()
+        resolution.title = item['source_title']
+        resolution.save()
         suggestion, created = SuggestionModel.objects.get_or_create(
             source_resolution=resolution,
             source_index=item['source_index'],

--- a/manoseimas/scrapy/pipelines.py
+++ b/manoseimas/scrapy/pipelines.py
@@ -24,6 +24,7 @@ from manoseimas.mps_v2.models import StenogramTopic as StenogramTopicModel
 from manoseimas.mps_v2.models import Voting, LawProject
 from manoseimas.mps_v2.models import Suggestion as SuggestionModel
 from manoseimas.mps_v2.models import Suggester as SuggesterModel
+from manoseimas.mps_v2.models import CommitteeResolution
 
 import manoseimas.lobbyists.models as lobbyists_models
 
@@ -348,11 +349,14 @@ class ManoSeimasModelPersistPipeline(object):
     @transaction.atomic
     def process_suggestion(self, item, spider):
         suggester, created = SuggesterModel.objects.get_or_create(
-            title=item['submitter']
+            title=item['submitter'],
+        )
+        resolution, created = CommitteeResolution.objects.get_or_create(
+            source_id=item['source_id'],
         )
         suggestion, created = SuggestionModel.objects.get_or_create(
-            source_id=item['source_id'],
-            source_index=item['source_index']
+            source_resolution=resolution,
+            source_index=item['source_index'],
         )
         suggestion.submitter.add(suggester)
         suggestion.date = item['date'] or None

--- a/manoseimas/scrapy/spiders/suggestions.py
+++ b/manoseimas/scrapy/spiders/suggestions.py
@@ -55,6 +55,7 @@ class SuggestionsSpider(ManoSeimasSpider):
 
     def parse_document(self, response):
         source_id = self._get_query_attr(response.url, 'p_id')
+        source_title = self._parse_title(response)
         tables = response.xpath("//div/table")
         empties = 0
         source_index = 0
@@ -65,6 +66,7 @@ class SuggestionsSpider(ManoSeimasSpider):
                     continue
                 item['source_id'] = source_id
                 item['source_index'] = source_index
+                item['source_title'] = source_title
                 yield item
                 source_index += 1
         if empties:
@@ -80,6 +82,10 @@ class SuggestionsSpider(ManoSeimasSpider):
             #   (1st suggestion is unattributed)
             self.log("{n} empty rows discarded at {url}".format(n=empties, url=response.url),
                      level=logging.WARNING)
+
+    def _parse_title(self, response):
+        caption = response.xpath('//body/table//caption')
+        return self._extract_text(caption[0]) if caption else ''
 
     def _parse_table(self, table, url):
         if not self._is_table_interesting(table, url):

--- a/manoseimas/scrapy/tests/test_suggestions.py
+++ b/manoseimas/scrapy/tests/test_suggestions.py
@@ -1367,9 +1367,14 @@ class TestSuggestionsSpider(unittest.TestCase):
         self.assertEqual(items[0]['date'], u'2015-09-08')
         self.assertEqual(items[0]['opinion'], 'Pritarti')
         self.assertEqual(items[0]['source_url'], response.url)
+        self.assertEqual(items[0]['source_title'], u'KOMITETO IŠVADA Seimo nutarimo „Dėl Lietuvos Respublikos Seimo VII (rudens) sesijos darbų programos“ projektui')
 
     def test_empty_rows(self):
         self.check('''
+          <table>
+            <caption>PAGRINDINIO KOMITETO IŠVADA dėl testavimo<br><br></caption>
+          </table>
+          <div>
             <table>
               <tr>
                 <td rowspan=2>Eil Nr.</td>
@@ -1405,6 +1410,7 @@ class TestSuggestionsSpider(unittest.TestCase):
                 <td></td>
               </tr>
             </table>
+          </div>
         ''', [
             Suggestion(
                 submitter=u'Lietuvos Respublikos Vyriausybė',
@@ -1414,13 +1420,14 @@ class TestSuggestionsSpider(unittest.TestCase):
                 source_url='http://localhost/test.html?p_id=12345',
                 source_id='12345',
                 source_index=0,
+                source_title=u'PAGRINDINIO KOMITETO IŠVADA dėl testavimo',
                 raw=u'LR Vyriausybė, 2015-10-09',
             ),
         ])
 
     def check(self, html, expected):
         response = HtmlResponse('http://localhost/test.html?p_id=12345',
-                                body='<body><div>%s</div></body>' % html)
+                                body='<body>%s</body>' % html)
         spider = SuggestionsSpider()
         actual = list(spider.parse_document(response))
         self.assertEqual(actual, expected)


### PR DESCRIPTION
This changes the database model:

 - adds a new CommitteeResolution table
 - makes Suggestion.source_id a foreign key
 - migrates existing data by creating fake CommitteeResolution objects with
   empty titles

Be sure to run bin/scrapy crawl suggestions to backfill actual resolution
titles after you apply the migrations.

Fixes #113.