### PR TITLE
Makefile gardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,6 @@ mkdirs: var/log var/www/static var/www/media
 
 var/log var/www/static var/www/media: ; mkdir -p $@
 
-widget: manoseimas/widget/frontend/.done
-
-manoseimas/widget/frontend/.done: bin/sassc manoseimas/widget/frontend/scripts/*.coffee manoseimas/widget/frontend/templates/*.handlebars
-	$(MAKE) -C manoseimas/widget/frontend
-
 bin/django bin/sassc: bin/buildout buildout.cfg $(wildcard config/*.cfg) $(wildcard config/env/*.cfg) setup.py
 	bin/buildout
 	touch -c $@
@@ -52,3 +47,9 @@ import_backup: bin/django
 	bin/django couchdb_sync_id
 
 .PHONY: all help run mkdirs widget tags migrate import_backup
+
+here := manoseimas/widget/frontend
+include $(here)/Makefile
+widget: $(widget_stamp)
+# one extra dependency
+$(widget_stamp): bin/sassc

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,7 @@ manoseimas/widget/frontend/.done: bin/sassc manoseimas/widget/frontend/scripts/*
 
 bin/django bin/sassc: bin/buildout buildout.cfg $(wildcard config/*.cfg) $(wildcard config/env/*.cfg) setup.py
 	bin/buildout
-	touch -c bin/django
-	touch -c bin/sassc
+	touch -c $@
 
 migrate: bin/django ; bin/django migrate
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ buildout.cfg: ; ./scripts/genconfig.py config/env/development.cfg
 
 bin/pip: ; virtualenv --no-site-packages --python=python2.7 .
 
-bin/buildout: bin/pip ; $< install zc.buildout==2.3.1
+bin/buildout: bin/pip
+	bin/pip install zc.buildout==2.3.1
 
 mkdirs: var/log var/www/static var/www/media
 
@@ -36,7 +37,7 @@ manoseimas/widget/frontend/.done: bin/sassc manoseimas/widget/frontend/scripts/*
 	$(MAKE) -C manoseimas/widget/frontend
 
 bin/django bin/sassc: bin/buildout buildout.cfg $(wildcard config/*.cfg) $(wildcard config/env/*.cfg) setup.py
-	$<
+	bin/buildout
 	touch -c bin/django
 	touch -c bin/sassc
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ var/log var/www/static var/www/media: ; mkdir -p $@
 
 bin/django bin/sassc: bin/buildout buildout.cfg $(wildcard config/*.cfg) $(wildcard config/env/*.cfg) setup.py
 	bin/buildout
-	touch -c $@
+	touch -c bin/django
+	touch -c bin/sassc
 
 migrate: bin/django ; bin/django migrate
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ bin/pip: ; virtualenv --no-site-packages --python=python2.7 .
 
 bin/buildout: bin/pip
 	bin/pip install zc.buildout==2.3.1
+	touch -c $@
 
 mkdirs: var/log var/www/static var/www/media
 

--- a/manoseimas/widget/frontend/Makefile
+++ b/manoseimas/widget/frontend/Makefile
@@ -1,9 +1,19 @@
-all: .done
+# non-recursive make support
+here ?= .
 
-.done: tmp scripts/*.coffee templates/*.handlebars
-	npm instal .
-	PATH=$(PATH):node_modules/.bin node_modules/.bin/cake build
-	touch .done
+tmpdir := $(here)/tmp
+scripts := $(here)/scripts/*.coffee
+templates := $(here)/templates/*.handlebars
+widget_stamp := $(here)/.done
+bindir := node_modules/.bin
 
-tmp:
+.PHONY: all
+all: $(widget_stamp)
+
+$(widget_stamp): $(tmpdir) $(scripts) $(templates)
+	cd $(here) && npm install .
+	cd $(here) && PATH=$(PATH):$(bindir) $(bindir)/cake build
+	touch $@
+
+$(tmpdir):
 	mkdir -p $@


### PR DESCRIPTION
My goal is to see

```
$ make
make: Nothing to be done for `all'.
```

when there's nothing that should be done.  To this end:

- Make sure Make makes progress when bin/pip is newer than bin/buildout
- Make sure Make makes progress when bin/sassc is newer than
  manoseimas/widget/frontend/.done (by avoiding recursive make invocations,
  because the widget Makefile doesn't know nor care about bin/sassc).