### PR TITLE
Update Django and all other deps to latest versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ buildout.cfg: ; ./scripts/genconfig.py config/env/development.cfg
 bin/pip: ; virtualenv --no-site-packages --python=python2.7 .
 
 bin/buildout: bin/pip
-	bin/pip install zc.buildout==2.3.1
+	bin/pip install zc.buildout==2.4.6
 	touch -c $@
 
 mkdirs: var/log var/www/static var/www/media

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,9 @@ tags: bin/django ; bin/ctags -v --tag-relative
 
 buildout.cfg: ; ./scripts/genconfig.py config/env/development.cfg
 
-bin/pip: ; virtualenv --no-site-packages --python=python2.7 .
+bin/pip:
+	virtualenv --no-site-packages --python=python2.7 .
+	bin/pip install -U pip setuptools wheel
 
 bin/buildout: bin/pip
 	bin/pip install zc.buildout==2.4.6

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ tags: bin/django ; bin/ctags -v --tag-relative
 buildout.cfg: ; ./scripts/genconfig.py config/env/development.cfg
 
 bin/pip:
+	rm -rf lib
 	virtualenv --no-site-packages --python=python2.7 .
 	bin/pip install -U pip setuptools wheel
 

--- a/config/base.cfg
+++ b/config/base.cfg
@@ -29,18 +29,17 @@ django-settings = ${django:dotted-settings-path}
 
 [django]
 recipe = djangorecipe
-projectegg = manoseimas-lt
 dotted-settings-path = manoseimas.settings.production
 wsgi = true
 eggs =
-    ${django:projectegg}
+    manoseimas-lt
     ipython
     ipdb
 
 
 [scrapy]
 recipe = zc.recipe.egg:scripts
-eggs = ${django:projectegg}
+eggs = manoseimas-lt
 entry-points =
     scrapy=scrapy.cmdline:execute
 
@@ -53,7 +52,7 @@ eggs =
 
 [ctags]
 recipe = z3c.recipe.tag:tags
-eggs = ${django:projectegg}
+eggs = manoseimas-lt
 
 
 [sass]

--- a/config/env/development.cfg
+++ b/config/env/development.cfg
@@ -13,7 +13,7 @@ wsgi = false
 [nose]
 recipe = zc.recipe.egg:scripts
 eggs =
-  ${django:projectegg}
+  manoseimas-lt
   nose
 scripts = nosetests
 initialization =

--- a/config/versions.cfg
+++ b/config/versions.cfg
@@ -4,26 +4,35 @@ update-versions-file = config/versions.cfg
 
 [versions]
 
-# Added by buildout at 2015-05-22 15:17:37.184260
-SQLAlchemy = 1.0.4
-Twisted = 15.2.0
-Unidecode = 0.4.17
-cffi = 1.0.3
-cryptography = 0.9
+
+# Added by buildout at 2015-10-28 10:31:08.066790
+PyExecJS = 1.1.0
+PyJWT = 1.4.0
+SQLAlchemy = 1.0.9
+Twisted = 15.4.0
+Unidecode = 0.4.18
+cffi = 1.3.0
+characteristic = 14.3.0
+cryptography = 1.0.2
 cssselect = 0.9.1
-djangorecipe = 1.11
-futures = 3.0.2
+django-appconf = 1.0.1
+djangorecipe = 2.1.2
+hexagonit.recipe.download = 1.7
 http-parser = 0.8.3
-mr.developer = 1.31
-oauth2 = 1.5.211
+idna = 2.0
+mr.developer = 1.34
+oauthlib = 1.0.3
+pbr = 1.8.1
+ptyprocess = 0.5
 python-openid = 2.2.5
-restkit = 4.2.2
-six = 1.9.0
+requests = 2.8.1
+requests-oauthlib = 0.5.0
+simplegeneric = 0.8.1
 socketpool = 0.5.3
-w3lib = 1.11.0
+w3lib = 1.12.0
 z3c.recipe.tag = 0.8
-zc.recipe.egg = 2.0.1
-zope.interface = 4.1.2
+zc.recipe.egg = 2.0.3
+zope.interface = 4.1.3
 
 # Required by:
 # django-test-utils==0.3
@@ -34,9 +43,9 @@ BeautifulSoup = 3.2.1
 CouchDB = 1.0
 
 # Required by:
-# djangorecipe==1.11
+# djangorecipe==2.1.2
 # manoseimas-lt==0.1
-Django = 1.8.3
+Django = 1.8.5
 
 # Required by:
 # manoseimas-lt==0.1
@@ -44,11 +53,15 @@ MySQL-python = 1.2.5
 
 # Required by:
 # manoseimas-lt==0.1
-Pillow = 2.8.1
+Pillow = 3.0.0
 
 # Required by:
 # manoseimas-lt==0.1
-Scrapy = 0.24.6
+PyReact = 0.5.2
+
+# Required by:
+# manoseimas-lt==0.1
+Scrapy = 1.0.3
 
 # Required by:
 # manoseimas-lt==0.1
@@ -56,23 +69,40 @@ Werkzeug = 0.10.4
 
 # Required by:
 # manoseimas-lt==0.1
-couchdbkit = 0.6.5
+coverage = 4.0.1
+
+# Required by:
+# ipython==4.0.0
+# traitlets==4.0.0
+decorator = 4.0.4
 
 # Required by:
 # manoseimas-lt==0.1
-coverage = 3.7.1
+django-autoslug = 1.9.3
 
 # Required by:
 # manoseimas-lt==0.1
-django-debug-toolbar = 1.3.0
+django-compressor = 1.5
 
 # Required by:
 # manoseimas-lt==0.1
-django-extensions = 1.5.5
+django-debug-toolbar = 1.4
 
 # Required by:
 # manoseimas-lt==0.1
-django-nose = 1.4
+django-extensions = 1.5.7
+
+# Required by:
+# manoseimas-lt==0.1
+django-jsonfield = 0.9.15
+
+# Required by:
+# manoseimas-lt==0.1
+django-libsass = 0.4
+
+# Required by:
+# manoseimas-lt==0.1
+django-nose = 1.4.2
 
 # Required by:
 # manoseimas-lt==0.1
@@ -83,24 +113,28 @@ django-pdb = 0.4.2
 django-test-utils = 0.3
 
 # Required by:
-# cryptography==0.9
+# django-sboard==0.1
+docutils = 0.12
+
+# Required by:
+# cryptography==1.0.2
 enum34 = 1.0.4
 
 # Required by:
-# oauth2==1.5.211
-httplib2 = 0.9.1
+# manoseimas-lt==0.1
+exportrecipe = 0.2
 
 # Required by:
-# cryptography==0.9
-idna = 2.0
+# mock==1.3.0
+funcsigs = 0.4
 
 # Required by:
-# cryptography==0.9
-ipaddress = 1.0.7
+# cryptography==1.0.2
+ipaddress = 1.0.14
 
 # Required by:
 # manoseimas-lt==0.1
-ipdb = 0.8
+ipdb = 0.8.1
 
 # Required by:
 # manoseimas-lt==0.1
@@ -109,35 +143,63 @@ ipdbplugin = 1.4.2
 # Required by:
 # ipdbplugin==1.4.2
 # manoseimas-lt==0.1
-ipython = 3.1.0
+ipython = 4.0.0
 
 # Required by:
-# Scrapy==0.24.6
+# traitlets==4.0.0
+ipython-genutils = 0.1.0
+
+# Required by:
+# manoseimas-lt==0.1
+leveldb = 0.193
+
+# Required by:
+# manoseimas-lt==0.1
+libsass = 0.8.3
+
+# Required by:
+# Scrapy==1.0.3
 lxml = 3.4.4
 
 # Required by:
 # manoseimas-lt==0.1
-mock = 1.0.1
+mock = 1.3.0
 
 # Required by:
 # ipdbplugin==1.4.2
-nose = 1.3.6
+nose = 1.3.7
+
+# Required by:
+# pickleshare==0.5
+path.py = 8.1.2
+
+# Required by:
+# ipython==4.0.0
+pexpect = 4.0.1
+
+# Required by:
+# ipython==4.0.0
+pickleshare = 0.5
 
 # Required by:
 # django-sboard==0.1
-psutil = 2.2.1
+psutil = 3.2.2
 
 # Required by:
-# Scrapy==0.24.6
+# Scrapy==1.0.3
 pyOpenSSL = 0.15.1
 
 # Required by:
-# cryptography==0.9
-pyasn1 = 0.1.7
+# service-identity==14.0.0
+pyasn1 = 0.1.9
 
 # Required by:
-# cffi==1.0.2
-pycparser = 2.13
+# service-identity==14.0.0
+pyasn1-modules = 0.0.8
+
+# Required by:
+# cffi==1.3.0
+pycparser = 2.14
 
 # Required by:
 # manoseimas-lt==0.1
@@ -145,109 +207,53 @@ pycrypto = 2.6.1
 
 # Required by:
 # manoseimas-lt==0.1
-pylibmc = 1.4.3
-
-# Required by:
-# Scrapy==0.24.6
-queuelib = 1.2.2
+pylibmc = 1.5.0
 
 # Required by:
 # manoseimas-lt==0.1
-sorl-thumbnail = 12.2
+python-social-auth = 0.2.13
 
 # Required by:
-# django-debug-toolbar==1.3.0
-sqlparse = 0.1.15
-
-# Required by:
-# django-sboard==0.1
-zope.component = 4.2.1
-
-# Required by:
-# zope.component==4.2.1
-zope.event = 4.0.3
-
-# Added by buildout at 2015-05-22 15:39:51.317662
-collective.recipe.template = 1.11
-exportrecipe = 0.2
-
-# Added by buildout at 2015-05-22 16:09:47.306292
-
-# Required by:
-# django-sboard==0.1
-docutils = 0.12
-
-# Added by buildout at 2015-05-22 16:41:42.595424
-hexagonit.recipe.download = 1.7
-
-# Added by buildout at 2015-05-22 17:34:28.170391
-
-# Required by:
-# manoseimas-lt==0.1
-libsass = 0.8.2
-
-# Added by buildout at 2015-05-23 11:59:33.832712
-django-appconf = 1.0.1
-
-# Required by:
-# manoseimas-lt==0.1
-django-compressor = 1.5
-
-# Added by buildout at 2015-05-23 12:09:14.937414
-
-# Required by:
-# manoseimas-lt==0.1
-django-libsass = 0.3
-
-# Required by:
-# manoseimas-lt==0.1
-django-autoslug = 1.8.0
-
-# Added by buildout at 2015-05-27 12:19:50.318262
-
-# Required by:
-# manoseimas-lt==0.1
-leveldb = 0.193
-
-# Added by buildout at 2015-06-03 10:54:49.807298
-
-# Required by:
-# manoseimas-lt==0.1
-tqdm = 1.0
-
-# Added by buildout at 2015-06-08 08:42:28.761082
+# Scrapy==1.0.3
+queuelib = 1.4.2
 
 # Required by:
 # manoseimas-lt==0.1
 roman = 2.0.0
 
-# Added by buildout at 2015-06-09 09:38:05.522534
-PyJWT = 1.3.0
-oauthlib = 0.7.2
-requests = 2.7.0
-requests-oauthlib = 0.5.0
+# Required by:
+# Scrapy==1.0.3
+service-identity = 14.0.0
 
-# Added by buildout at 2015-06-12 11:51:56.133625
+# Required by:
+# libsass==0.8.3
+# manoseimas-lt==0.1
+six = 1.10.0
+
+# Required by:
+# manoseimas-lt==0.1
+sorl-thumbnail = 12.3
+
+# Required by:
+# django-debug-toolbar==1.4
+sqlparse = 0.1.18
 
 # Required by:
 # manoseimas-lt==0.1
 toposort = 1.4
 
-# Added by buildout at 2015-06-15 11:51:25.095081
-
 # Required by:
 # manoseimas-lt==0.1
-django-jsonfield = 0.9.13
-
-# Added by buildout at 2015-06-17 13:21:51.634014
-PyExecJS = 1.1.0
+tqdm = 2.0.0
 
 # Required by:
-# manoseimas-lt==0.1
-PyReact = 0.5.2
-
-# Added by buildout at 2015-07-11 10:15:12.649408
+# ipython==4.0.0
+traitlets = 4.0.0
 
 # Required by:
-# manoseimas-lt==0.1
-python-social-auth = 0.2.12
+# django-sboard==0.1
+zope.component = 4.2.2
+
+# Required by:
+# zope.component==4.2.2
+zope.event = 4.1.0

--- a/manoseimas/settings/base.py
+++ b/manoseimas/settings/base.py
@@ -101,7 +101,6 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'django.core.context_processors.request',
                 'manoseimas.context_processors.settings_for_context',
             ],
             'loaders': [

--- a/manoseimas/settings/base.py
+++ b/manoseimas/settings/base.py
@@ -90,26 +90,6 @@ COMPRESS_PRECOMPILERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = config.secret_key
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    ('pyjade.ext.django.Loader', (
-        'django.template.loaders.filesystem.Loader',
-        'django.template.loaders.app_directories.Loader',
-        'django.template.loaders.eggs.Loader',
-    ))
-)
-
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.contrib.messages.context_processors.messages',
-    'django.core.context_processors.request',
-    'manoseimas.context_processors.settings_for_context',
-)
-
 
 TEMPLATES = [
     {


### PR DESCRIPTION
Note: if your buildout fails with `Error: Couldn't install: mock 1.3.0`, then you must upgrade `setuptools` in your virtualenv:

    bin/pip install -U setuptools

I don't know how to get the Makefile to do that automatically.

(Ok, I lie, I could probably come up with something.  But it seems complicated.)