### PR TITLE
Handle dash-separated last names

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -50,6 +50,64 @@ And run the project::
     make run
 
 
+OSX Setup
+---------
+
+You will need to run MySQL 5.7 in OSX. Cleanest way to do that is to use Docker
+for OSX and ``docker-compose``::
+
+    docker-compose up -d  # -d will run in daemon mode.
+
+You will likely need some headers for mysql and a client, so you'll have to install
+these (mysql server won't get run unless enabled)::
+
+    brew install mysql
+
+Create mysql user::
+
+    mysql -u root
+      CREATE DATABASE IF NOT EXISTS manoseimas CHARSET=utf8;
+      CREATE USER 'manoseimas'@'localhost';
+      GRANT ALL PRIVILEGES ON *.* TO 'manoseimas'@'localhost';
+      FLUSH PRIVILEGES;
+
+Build the project::
+
+    make
+
+Install npm packages::
+
+    npm install
+
+Create mysql config file::
+
+    vim ~/.my.cnf
+      [client]
+      host = 127.0.0.1
+      database = manoseimas
+      user = manoseimas
+      password =
+      default-character-set = utf8
+
+Run migrations::
+
+    bin/django migrate
+
+And run the project::
+
+    make run
+
+Run tests::
+
+    make test
+
+If you see a problem migrating permissions in tests (``OperationalError``
+any tests are run), recreate the test DB with ``utf-8`` encoding.
+(TODO: This should be automated)::
+
+    mysql -e 'DROP DATABASE IF EXISTS test_manoseimas; CREATE DATABASE test_manoseimas CHARSET=utf8;'
+
+
 Vagrant setup
 -------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+db:
+  image: mysql:5.7
+  ports:
+    - "3306:3306"
+  environment:
+    - MYSQL_ALLOW_EMPTY_PASSWORD=1

--- a/manoseimas/scrapy/pipelines.py
+++ b/manoseimas/scrapy/pipelines.py
@@ -140,9 +140,15 @@ class MPNameMatcher(object):
         mp = self.mp_names.get(mp_name)
         if not mp:
             parts = mp_name.split(' ')
-            if len(parts) >= 2:
-                mp_name = ' '.join((parts[0], parts[-1]))
-                mp = self.mp_names.get(mp_name.upper())
+            if len(parts) > 2:
+                new_mp_name = ' '.join((parts[0], parts[-1]))
+                mp = self.mp_names.get(new_mp_name.upper())
+            elif len(parts) == 2:
+                # Handle double last names with a dash instead of a space
+                last_name = parts[-1]
+                adjusted_last_name = ' '.join(last_name.split('-'))
+                new_mp_name = ' '.join([parts[0], adjusted_last_name])
+                mp = self.mp_names.get(new_mp_name.upper())
         return mp
 
 

--- a/manoseimas/scrapy/spiders/stenograms.py
+++ b/manoseimas/scrapy/spiders/stenograms.py
@@ -107,7 +107,7 @@ class StenogramSpider(ManoSeimasSpider):
     start_urls = ['http://www3.lrs.lt/pls/inter/w5_sale.kad_ses']
 
     stenogram_link_extractor = LxmlLinkExtractor(
-        allow=[r'/pls/inter/dokpaieska.showdoc_l\?p_id=\d+'],
+        allow=[r'/pls/inter\d?/dokpaieska.showdoc_l\?p_id=\d+'],
         restrict_xpaths=[('//a[text()="Stenograma"]')]
     )
 

--- a/manoseimas/settings/base.py
+++ b/manoseimas/settings/base.py
@@ -41,7 +41,7 @@ MANAGERS = ADMINS
 
 ATOMIC_REQUESTS = True
 
-if DIST == ('Ubuntu', '16.04'):
+if DIST == ('Ubuntu', '16.04') or platform.system() == 'Darwin':
     # With MySQL 5.7 the command SET storage_engine=MyISAM won't work.
     # http://stackoverflow.com/a/37220446/475477
     init_command = 'SET default_storage_engine=INNODB'


### PR DESCRIPTION
Adds a special case to normalize dash-separated surnames. This is needed because some MPs have their double surnames separated by a space in lrs.lt profiles but dash-separated in transcripts.

Also added a few changes to make it easier to develop Manoseimas on OSX.